### PR TITLE
Return Consul key value for check

### DIFF
--- a/assets/lib/check.js
+++ b/assets/lib/check.js
@@ -13,7 +13,7 @@ function checkAction() {
       client.get(source.key)
         .then(value => {
           resolve([{
-            ref: Date.now().toString()
+            value: value.value
           }]);
         }, rejected => {
           handlers.fail(rejected)

--- a/test/check_test.js
+++ b/test/check_test.js
@@ -19,7 +19,7 @@ describe('checkAction', () => {
     stdin = require('mock-stdin').stdin();
   });
 
-  it('gets the Consul key configured in the source and resolves its promise with a timestamp as its ref', () => {
+  it('gets the Consul key configured in the source and resolves its promise with the value', () => {
     mockGet();
 
     process.nextTick(() => {
@@ -36,7 +36,8 @@ describe('checkAction', () => {
 
     return checkAction()
       .then(result => {
-        assert.equal(typeof(result[0].ref), 'string');
+        assert.equal(result.length, 1);
+        assert.deepEqual(result[0], { value: 'my-value' });
       }, rejected => {
         console.log('rejected: ', rejected);
       });


### PR DESCRIPTION
By returning the current value of the key path instead of the timestamps,
we can trigger concourse jobs when consul key values change.

I haven't written much node/javascript in a few years, `node test` passes but you may want to give it a look over yourself just to be safe :)

Thanks again for the resource!

Closes #1 